### PR TITLE
PHP 7 Fix array

### DIFF
--- a/code/Model/Call.php
+++ b/code/Model/Call.php
@@ -95,7 +95,7 @@ class Meanbee_Postcode_Model_Call {
         
         //Create the response
         foreach ($data->Data->children() as $row) {
-            $rowItems="";
+            $rowItems=[];
             foreach($row->attributes() as $key => $value) {
                 $rowItems[$key]=strval($value);
             }
@@ -138,7 +138,7 @@ class Meanbee_Postcode_Model_Call {
         
         //Create the response
         foreach ($data->Data->children() as $row) {
-            $rowItems="";
+            $rowItems=[];
             foreach($row->attributes() as $key => $value) {
                 $rowItems[$key]=strval($value);
             }


### PR DESCRIPTION
Initialising a var as a string then using it as an array is not supported in PHP 7